### PR TITLE
add the 'fitBounds()' functionality

### DIFF
--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -28,6 +28,7 @@ class GoogleMapPlotter(object):
         self.coloricon = os.path.join(os.path.dirname(__file__), 'markers/%s.png')
         self.color_dict = mpl_color_map
         self.html_color_codes = html_color_codes
+        self._fitBounds = None
 
     @classmethod
     def from_geocode(cls, location_string, zoom=13):
@@ -168,6 +169,13 @@ class GoogleMapPlotter(object):
         shape = zip(lats, lngs)
         self.shapes.append((shape, settings))
 
+    def fitBounds(self, latNE, lngNE, latSW, lngSW):
+        """adjust the map zoom to fit the given bounds"""
+
+        # TODO: the bounds coords could be computed automatically, by updating them
+        #       for every new object added to the map
+        self._fitBounds = (latNE, lngNE, latSW, lngSW)
+
     # create the html file which include one google map and all points and
     # paths
     def draw(self, htmlfile):
@@ -188,6 +196,7 @@ class GoogleMapPlotter(object):
         self.write_paths(f)
         self.write_shapes(f)
         self.write_heatmap(f)
+        self.write_fitBounds(f)
         f.write('\t}\n')
         f.write('</script>\n')
         f.write('</head>\n')
@@ -358,6 +367,14 @@ class GoogleMapPlotter(object):
             f.write('});' + '\n')
             f.write('heatmap.setMap(map);' + '\n')
             f.write(settings_string)
+
+    def write_fitBounds(self, f):
+        if self._fitBounds:
+            f.write('\n')
+            f.write('rectBounds = new google.maps.LatLngBounds(\n')
+            f.write('    new google.maps.LatLng(%f, %f),\n'  % self._fitBounds[:2])
+            f.write('    new google.maps.LatLng(%f, %f));\n' % self._fitBounds[2:])
+            f.write('map.fitBounds(rectBounds);\n')
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
This function takes 2 sets of arguments, the North-East Lat/Lng and the
South-West Lat/Lng, which are used to compute a LatLngBounds() which is then
passed to the gmap fitBounds() method.

The result is a map with the correct zoom to show the NE-SW region.

As a possible improvement, we could automatically store the NE/SW corners for
every new object added to the map (via gmplot methods) and then just
'requesting' to fit those bounds by flipping a True/False flag.